### PR TITLE
Implement put_file function

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -44,6 +44,13 @@ Executable "get_file"
   Install:      false
   CompiledObject: best
 
+Executable "put_file"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       put_file.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
 
 Document API
   Title:           API reference for Dropbox

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -27,6 +27,8 @@ type error =
   | Quota_exceeded of error_description
   (** User is over Dropbox storage quota. *)
   | Server_error of int * error_description
+  | Conflict of error_description
+  | Length_required of error_description
 
 val string_of_error : error -> string
 
@@ -259,6 +261,9 @@ module type S = sig
         including [start]).  If [start <= 0], the metadata will be present
         but the stream will be empty. *)
 
+  val put_file : t -> ?locale: string -> ?overwrite: bool ->
+                 ?parent_rev: string -> ?autorename: bool -> string ->
+                 int -> string Lwt_stream.t -> metadata Lwt.t
   ;;
 end
 

--- a/tests/put_file.ml
+++ b/tests/put_file.ml
@@ -1,0 +1,24 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+let upload t fn =
+  Lwt_unix.(openfile fn [O_RDONLY] 0) >>= fun fd ->
+  let read () =
+    let buffer = String.create 1024 in
+    Lwt_unix.read fd buffer 0 1024 >>= fun len ->
+    match len with
+    | 1024 -> return(Some buffer)
+    | 0 -> return(None)
+    | a -> return(Some (String.sub buffer 0 a)) in
+  let stream =Lwt_stream.from read in
+  Lwt_unix.stat fn >>= fun u -> return(u.Lwt_unix.st_size) >>= fun size ->
+  D.put_file t fn size stream >>= fun metadata ->
+  Lwt_unix.close fd >>= fun () -> Lwt_io.printlf "Sended %s" fn
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file specified"
+  | _ -> Lwt_list.iter_p (upload t) args
+
+let () =
+  Common.run main


### PR DESCRIPTION
Bonjour,
J'ai encore essayé sans succès de résoudre le problème de ma fonction lorsque j'insère le Content-length dans le header (à noter que quand je l'omets, mon fichier est bien envoyé et l'erreur 409 de conflit est gérée et il ne m'engueule même pas pour l'erreur 411 (missing content-length) qui devrait être levée).

Lorsque j'envoie un fichier texte, je peux voir que dans le fichier écrit sur le serveur de dropbox, le body? a aussi envoyé et donc écrit la longueur de chaque buffer entre chaque chaîne de caractères. De ce fait, le content-length devient trop petit et les derniers caractères ne sont pas transmis (même en l'augmentant, je n'arrive pas à retrouver mon fichier texte sans les tailles de buffer inscrites).

Je suis ici en train de lire de manière plus approfondie cohttp pour y trouver un début de solution.
