### PR TITLE
Thumbnails function

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -44,6 +44,14 @@ Executable "get_file"
   Install:      false
   CompiledObject: best
 
+Executable "thumbnails"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       thumbnails.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
 
 Document API
   Title:           API reference for Dropbox

--- a/src/dropbox.atd
+++ b/src/dropbox.atd
@@ -61,7 +61,7 @@ type metadata = { size: string;
                   ?video_info: video_info option;
                   icon: string;
                   modified: date;
-                  client_mtime: date option;
+                  ?client_mtime: date option;
                   root: root;
                   ~contents: metadata list
                 }

--- a/src/dropbox.atd
+++ b/src/dropbox.atd
@@ -41,6 +41,13 @@ type root = [
   | App_folder  <json name="app_folder">
   ]
 
+type photo_info = { ?time_taken: date option;
+                    ~lat_long: float list }
+
+type video_info = { ?time_taken: date option;
+                    ~duration: float;
+                    ~lat_long: float list }
+
 type metadata = { size: string;
                   bytes: int;
                   ~mime_type: string;
@@ -50,10 +57,11 @@ type metadata = { size: string;
                   rev: string;
                   ~hash: string;
                   thumb_exists: bool;
-                  (* photo_info; *)
-                  (* video_info; *)
+                  ?photo_info: photo_info option;
+                  ?video_info: video_info option;
                   icon: string;
                   modified: date;
-                  client_mtime: date;
+                  client_mtime: date option;
                   root: root;
+                  ~contents: metadata list
                 }

--- a/src/dropbox.atd
+++ b/src/dropbox.atd
@@ -63,5 +63,4 @@ type metadata = { size: string;
                   modified: date;
                   ?client_mtime: date option;
                   root: root;
-                  ~contents: metadata list
-                }
+                  ~contents: metadata list }

--- a/src/dropbox.atd
+++ b/src/dropbox.atd
@@ -64,3 +64,7 @@ type metadata = { size: string;
                   ?client_mtime: date option;
                   root: root;
                   ~contents: metadata list }
+
+type size = [ Xs | S | M | L | Xl ]
+
+type format = [ Jpeg | Png ]

--- a/src/dropbox.ml
+++ b/src/dropbox.ml
@@ -185,12 +185,14 @@ module type S = sig
       root: [ `Dropbox | `App_folder ];
       contents: metadata list
     }
-  type size =  [ `Xs | `S | `M | `L | `Xl ]
-
-  type format = [ `Jpeg | `Png ]
 
   val get_file : t -> ?rev: string -> ?start: int -> ?len: int ->
                  string -> (metadata * string Lwt_stream.t) option Lwt.t
+
+
+  type size =  [ `Xs | `S | `M | `L | `Xl ]
+
+  type format = [ `Jpeg | `Png ]
 
   val thumbnails : t -> ?format: format -> ?size: size ->
                    ?start: int -> ?len: int ->string ->

--- a/src/dropbox.ml
+++ b/src/dropbox.ml
@@ -149,6 +149,15 @@ module type S = sig
 
   val info : ?locale: string -> t -> info Lwt.t
 
+ type photo_info = Dropbox_t.photo_info
+                 = { time_taken: Date.t option;
+                     lat_long: float list }
+
+  type video_info = Dropbox_t.video_info
+                  = { time_taken: Date.t option;
+                      duration: float;
+                      lat_long: float list }
+
   type metadata = Dropbox_t.metadata = {
       size: string;
       bytes: int;
@@ -159,10 +168,13 @@ module type S = sig
       rev: string;
       hash: string;
       thumb_exists: bool;
+      photo_info: photo_info option;
+      video_info: video_info option;
       icon: string;
       modified: Date.t;
-      client_mtime: Date.t;
-      root: [ `Dropbox | `App_folder ]
+      client_mtime: Date.t option;
+      root: [ `Dropbox | `App_folder ];
+      contents: metadata list
     }
 
   val get_file : t -> ?rev: string -> ?start: int -> ?len: int ->

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -205,6 +205,17 @@ module type S = sig
       {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox
       documentation} for more information about supported locales.  *)
 
+  type photo_info
+    = Dropbox_t.photo_info
+    = { time_taken: Date.t option;
+        lat_long: float list }
+
+  type video_info
+    = Dropbox_t.video_info
+    = { time_taken: Date.t option;
+        duration: float;
+        lat_long: float list }
+
   type metadata = Dropbox_t.metadata = {
       size: string;
       (** A human-readable description of the file size (translated by
@@ -227,6 +238,15 @@ module type S = sig
       thumb_exists: bool;
       (** True if the file is an image that can be converted to a
           thumbnail via the {!thumbnails} call. *)
+      photo_info: photo_info option;
+      (** Only returned when the include_media_info parameter is true and the
+          file is an image. A dictionary that includes the creation time
+          (time_taken) and the GPS coordinates (lat_long). *)
+      video_info: video_info option;
+      (** Only returned when the include_media_info parameter is true and the
+          file is a video. A dictionary that includes the creation time
+          (time_taken), the GPS coordinates (lat_long), and the length of the
+           video in milliseconds (duration). *)
       icon: string;
       (** The name of the icon used to illustrate the file type in Dropbox's
           {{:https://www.dropbox.com/static/images/dropbox-api-icons.zip}icon
@@ -234,7 +254,7 @@ module type S = sig
       modified: Date.t;
       (** The last time the file was modified on Dropbox (not included
           for the root folder).  *)
-      client_mtime: Date.t;
+      client_mtime: Date.t option;
       (** For files, this is the modification time set by the desktop
           client when the file was added to Dropbox.  Since this time
           is not verified (the Dropbox server stores whatever the
@@ -244,6 +264,7 @@ module type S = sig
       root: [ `Dropbox | `App_folder ];
       (** The root or top-level folder depending on your access
           level. All paths returned are relative to this root level. *)
+      contents: metadata list;
     }
 
   val get_file : t -> ?rev: string -> ?start: int -> ?len: int ->
@@ -258,7 +279,6 @@ module type S = sig
         the entire file (or everything after the position [start],
         including [start]).  If [start <= 0], the metadata will be present
         but the stream will be empty. *)
-
   ;;
 end
 

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -27,6 +27,7 @@ type error =
   | Quota_exceeded of error_description
   (** User is over Dropbox storage quota. *)
   | Server_error of int * error_description
+  | Unsupported_media_type of error_description
 
 val string_of_error : error -> string
 
@@ -279,7 +280,10 @@ module type S = sig
         the entire file (or everything after the position [start],
         including [start]).  If [start <= 0], the metadata will be present
         but the stream will be empty. *)
-  ;;
+
+  val thumbnails : t -> ?format: string -> ?size: string ->
+                   ?start: int -> ?len: int ->string ->
+                   (metadata * string Lwt_stream.t) option Lwt.t
 end
 
 module Make(Client: Cohttp_lwt.Client) : S

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -268,9 +268,6 @@ module type S = sig
           level. All paths returned are relative to this root level. *)
       contents: metadata list;
     }
-  type size =  [ `Xs | `S | `M | `L | `Xl ]
-
-  type format = [ `Jpeg | `Png ]
 
   val get_file : t -> ?rev: string -> ?start: int -> ?len: int ->
                  string -> (metadata * string Lwt_stream.t) option Lwt.t
@@ -285,6 +282,11 @@ module type S = sig
       the entire file (or everything after the position [start],
       including [start]).  If [start <= 0], the metadata will be present
       but the stream will be empty. *)
+
+
+  type size =  [ `Xs | `S | `M | `L | `Xl ]
+
+  type format = [ `Jpeg | `Png ]
 
   val thumbnails : t -> ?format: format -> ?size: size ->
                    ?start: int -> ?len: int ->string ->
@@ -303,9 +305,11 @@ module type S = sig
       xs (32x32),s (64x64), m (128x128), l (640x480), xl (1024x768).
 
       Possible errors:
-      404 The file path wasn't found or the file extension doesn't allow
-      conversion to a thumbnail.
-      415 The image is invalid and cannot be converted to a thumbnail. *)
+      Not_found404 The file path wasn't found or the file extension doesn't
+      allow conversion to a thumbnail.
+
+      Unsupported_media_type The image is invalid and cannot be converted
+      to a thumbnail. *)
 end
 
 module Make(Client: Cohttp_lwt.Client) : S

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -27,6 +27,7 @@ type error =
   | Quota_exceeded of error_description
   (** User is over Dropbox storage quota. *)
   | Server_error of int * error_description
+  | Not_found404 of error_description
   | Unsupported_media_type of error_description
 
 val string_of_error : error -> string
@@ -274,16 +275,34 @@ module type S = sig
       its content.  [None] indicates that the file does not exists.
 
       @param start The first byte of the file to download.  A negative
-        number is interpreted as [0].  Default: [0].
+      number is interpreted as [0].  Default: [0].
+
       @param len The number of bytes to download.  If [start] is not set,
-        the last [len] bytes of the file are downloaded.  Default: download
-        the entire file (or everything after the position [start],
-        including [start]).  If [start <= 0], the metadata will be present
-        but the stream will be empty. *)
+      the last [len] bytes of the file are downloaded.  Default: download
+      the entire file (or everything after the position [start],
+      including [start]).  If [start <= 0], the metadata will be present
+      but the stream will be empty. *)
 
   val thumbnails : t -> ?format: string -> ?size: string ->
                    ?start: int -> ?len: int ->string ->
                    (metadata * string Lwt_stream.t) option Lwt.t
+  (** [thumbnails t path] return the metadata for the thumbnails and a
+      stream of its content.  [None] indicates that the file does not exists.
+
+      This method currently supports files with the following file extensions:
+      "jpg", "jpeg", "png", "tiff", "tif", "gif", and "bmp". Photos that are
+      larger than 20MB in size won't be converted to a thumbnail.
+
+      @param format jpeg (default) or png. For images that are photos, jpeg
+      should be preferred, while png is better for screenshots and digital art.
+
+      @param size One of the following values (default: s):
+      xs (32x32),s (64x64), m (128x128), l (640x480), xl (1024x768).
+
+      Possible errors:
+      404 The file path wasn't found or the file extension doesn't allow
+      conversion to a thumbnail.
+      415 The image is invalid and cannot be converted to a thumbnail. *)
 end
 
 module Make(Client: Cohttp_lwt.Client) : S

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -268,6 +268,9 @@ module type S = sig
           level. All paths returned are relative to this root level. *)
       contents: metadata list;
     }
+  type size =  [ `Xs | `S | `M | `L | `Xl ]
+
+  type format = [ `Jpeg | `Png ]
 
   val get_file : t -> ?rev: string -> ?start: int -> ?len: int ->
                  string -> (metadata * string Lwt_stream.t) option Lwt.t
@@ -283,7 +286,7 @@ module type S = sig
       including [start]).  If [start <= 0], the metadata will be present
       but the stream will be empty. *)
 
-  val thumbnails : t -> ?format: string -> ?size: string ->
+  val thumbnails : t -> ?format: format -> ?size: size ->
                    ?start: int -> ?len: int ->string ->
                    (metadata * string Lwt_stream.t) option Lwt.t
   (** [thumbnails t path] return the metadata for the thumbnails and a

--- a/tests/thumbnails.ml
+++ b/tests/thumbnails.ml
@@ -33,8 +33,6 @@ let download t ?(size="s") ?format fn =
        Lwt_io.printlf "Wrote a thumbnails of %S (%s, %s), %s"
                       fn m.D.size m.D.mime_type
                       (Dropbox.Date.to_string m.D.modified)
-(*   else
-     Lwt_io.printlf "The extension and the format must be the same." *)
 
 let main t args =
   match args with

--- a/tests/thumbnails.ml
+++ b/tests/thumbnails.ml
@@ -1,0 +1,30 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+let download t fn =
+  D.thumbnails t fn >>= function
+  | None -> Lwt_io.printlf "No image named %S." fn
+  | Some(m, stream) ->
+     (* Save stream to the disk *)
+     let fname = Filename.basename ("thumbnails_of_" ^ fn) in
+     Lwt_unix.(openfile fname [O_WRONLY; O_CREAT; O_TRUNC] 0o664)
+     >>= fun fd ->
+     let write s =
+       Lwt_unix.write fd s 0 (String.length s) >>= fun _ ->
+       return_unit in
+     Lwt_stream.iter_s write stream >>= fun () ->
+     Lwt_unix.close fd >>= fun () ->
+     Lwt_io.printlf "Wrote %S (%s, %s), %s"
+                    ("thumbnails_of_" ^ fn) m.D.size m.D.mime_type
+                    (Dropbox.Date.to_string m.D.modified)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file specified."
+  | _ ->
+     (* You can replace Lwt_list.iter_p by Lwt_list.iter_s for a
+        sequential download and see how much slower it is. *)
+     Lwt_list.iter_p (download t) args
+
+let () =
+  Common.run main

--- a/tests/thumbnails.ml
+++ b/tests/thumbnails.ml
@@ -1,30 +1,54 @@
 open Lwt
 module D = Dropbox_lwt_unix
 
-let download t fn =
-  D.thumbnails t fn >>= function
-  | None -> Lwt_io.printlf "No image named %S." fn
-  | Some(m, stream) ->
-     (* Save stream to the disk *)
-     let fname = Filename.basename ("thumbnails_of_" ^ fn) in
-     Lwt_unix.(openfile fname [O_WRONLY; O_CREAT; O_TRUNC] 0o664)
-     >>= fun fd ->
-     let write s =
-       Lwt_unix.write fd s 0 (String.length s) >>= fun _ ->
-       return_unit in
-     Lwt_stream.iter_s write stream >>= fun () ->
-     Lwt_unix.close fd >>= fun () ->
-     Lwt_io.printlf "Wrote %S (%s, %s), %s"
-                    ("thumbnails_of_" ^ fn) m.D.size m.D.mime_type
-                    (Dropbox.Date.to_string m.D.modified)
+(** If there is one entry, we call thumbnails with the path as Sys.argv.(0).
+    If there is two entries, we call thumbnails with the path as
+       Sys.argv.(0) and the param format as the second.
+    If there is three entries, we add the param size as the third argument *)
+
+let download t ?(size="s") ?format fn =
+  let y = String.index fn '.' in
+  let extension = String.sub fn (y + 1) (String.length fn - y - 1) in
+  (** Si le format que l'on a envoyé est égale à l'extension de l'image alors
+      ok. Si elle est différente, pour éviter les conflits, on renvoie
+      l'extension de l'image. Enfin, rien n'était spécifié dans format (un
+      seul argument, alors on met "" par défaut (les mauvaises extensions
+      sont gérées par 404. *)
+  let format = match format with
+    | Some f -> if extension = f then f
+                else extension
+    | None -> "" in (** .jpg files does work *)
+  D.thumbnails t ~size ~format fn >>= function
+    | None -> Lwt_io.printlf "No image named %S." fn
+    | Some(m, stream) ->
+       (* Save stream to the disk *)
+       let fname = Filename.basename ("thumbnails_of_" ^ fn) in
+       Lwt_unix.(openfile fname [O_WRONLY; O_CREAT; O_TRUNC] 0o664)
+       >>= fun fd ->
+       let write s =
+         Lwt_unix.write fd s 0 (String.length s) >>= fun _ ->
+         return_unit in
+       Lwt_stream.iter_s write stream >>= fun () ->
+       Lwt_unix.close fd >>= fun () ->
+       Lwt_io.printlf "Wrote a thumbnails of %S (%s, %s), %s"
+                      fn m.D.size m.D.mime_type
+                      (Dropbox.Date.to_string m.D.modified)
+(*   else
+     Lwt_io.printlf "The extension and the format must be the same." *)
 
 let main t args =
   match args with
   | [] -> Lwt_io.printlf "No file specified."
-  | _ ->
-     (* You can replace Lwt_list.iter_p by Lwt_list.iter_s for a
-        sequential download and see how much slower it is. *)
-     Lwt_list.iter_p (download t) args
+  | a -> if List.length a = 1 then
+           download t (List.hd a)
+	 else if List.length a = 2 then
+           match List.nth a 1, List.nth a 0 with
+           | fn, format -> download t ~format fn
+         else if List.length a = 3 then
+           match List.nth a 2, List.nth a 1, List.nth a 0 with
+           | fn, format, size -> download t ~format ~size fn
+	 else
+           Lwt_io.printlf "Thumbnails function take at least 3 arguments."
 
 let () =
   Common.run main


### PR DESCRIPTION
Concernant cette fonction, j'ai un petit souci.
Lorsque je rentre un mauvais format,  j'ai une bonne erreur qui m'est renvoyée : 
Error: Invalid_arg {"error":"format 'jppjjo' is invalid. Expected: ['bmp', 'png', 'jpeg']"}

Par contre, lorsque je fais de même avec le paramètre size, j'obtiens : 
Fatal error: exception Yojson.Json_error("Line 1, bytes 12-44:
Expected '"' but found '{"size": "size sxl not valid size"'")
Ce qui est ma foi plus embêtant et je ne vois pas comment le résoudre si ce n'est par faire un pattern matching afin d'être sur de renvoyer un bon argument (sur ce point-ci, je sors de ma fonction avec 
invalid_arg et je n'ai pas de manière plus élégante pour l'instant.
