### PR TITLE
revisions and restore functions using metadata as a parameter

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -76,6 +76,14 @@ Executable "longpoll_delta"
   Install:      false
   CompiledObject: best
 
+Executable "revisions"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       revisions.ml
+  BuildDepends: dropbox.lwt
+  Install:      false
+  CompiledObject: best
+
 
 Document API
   Title:           API reference for Dropbox

--- a/_oasis
+++ b/_oasis
@@ -84,6 +84,14 @@ Executable "revisions"
   Install:      false
   CompiledObject: best
 
+Executable "restore"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       restore.ml
+  BuildDepends: dropbox.lwt
+  Install:      false
+  CompiledObject: best
+
 
 Document API
   Title:           API reference for Dropbox

--- a/src/dropbox.atd
+++ b/src/dropbox.atd
@@ -65,6 +65,8 @@ type metadata = { size: string;
                   root: root;
                   ~contents: metadata list }
 
+type metadata_list = metadata list
+
 type delta_json = { ~entries: (string * metadata nullable) list;
                     reset: bool;
                     cursor: string;

--- a/src/dropbox.ml
+++ b/src/dropbox.ml
@@ -185,6 +185,8 @@ module type S = sig
       contents: metadata list;
     }
 
+  type metadata_list = metadata list
+
   type cursor
 
   (* It is better that [delta] is not shared between various
@@ -216,6 +218,9 @@ module type S = sig
                       -> t -> cursor Lwt.t
 
   val longpoll_delta : t -> ?timeout: int -> cursor -> longpoll_delta Lwt.t
+
+  val revisions : t -> ?rev_limit: int -> ?locale: string -> string ->
+                  metadata list option Lwt.t
 end
 
 module Make(Client: Cohttp_lwt.Client) = struct
@@ -461,4 +466,19 @@ module Make(Client: Cohttp_lwt.Client) = struct
     Client.get ~headers:(headers t) u >>= check_errors
     >>= fun(_, body) -> Cohttp_lwt_body.to_string body
     >>= fun body -> return(Json.longpoll_delta_of_string body)
+
+  let metadata_list_of_response (_, body) =
+    Cohttp_lwt_body.to_string body
+    >>= fun body -> return(Some(Json.metadata_list_of_string body))
+
+  let revisions t ?(rev_limit=10) ?(locale="") fn =
+    let u = Uri.of_string("https://api.dropbox.com/1/revisions/auto/" ^ fn) in
+    let rev_limit = if rev_limit < 0 then 0
+                    else if rev_limit > 1000 then 1000
+                    else rev_limit in
+    let q = [("rev_limit",[string_of_int rev_limit])] in
+    let q = if locale <> "" then ("locale",[locale]) :: q else q in
+    let u = Uri.with_query u q in
+    Client.get ~headers:(headers t) u
+    >>= check_errors_404 metadata_list_of_response
 end

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -278,6 +278,8 @@ module type S = sig
           contained in this folder. Return nothing if the folder is empty. *)
     }
 
+  type metadata_list = metadata list
+
   type cursor
 
   type delta = {
@@ -486,6 +488,19 @@ module type S = sig
       jitter added to avoid the thundering herd problem.  Care should
       be taken when using this parameter, as some network
       infrastructure does not support long timeouts. *)
+
+  val revisions : t -> ?rev_limit: int -> ?locale: string -> string ->
+                  metadata list option Lwt.t
+  (** [revisions t name] Return the metadata for the previous revisions of
+      a file (in a list of metadata). Only revisions up to thirty days old
+      are available. A return value of [None] means that the file does
+      not exists.
+      @param rev_limit Default is 10. Max is 1,000. Up to this number of
+      recent revisions will be returned.
+      @param locale Specify language settings for user error messages
+      and other language specific text. See
+      {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox
+      documentation} for more information about supported locales. *)
   ;;
 end
 

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -495,8 +495,23 @@ module type S = sig
       a file (in a list of metadata). Only revisions up to thirty days old
       are available. A return value of [None] means that the file does
       not exists.
+
       @param rev_limit Default is 10. Max is 1,000. Up to this number of
       recent revisions will be returned.
+
+      @param locale Specify language settings for user error messages
+      and other language specific text. See
+      {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox
+      documentation} for more information about supported locales. *)
+
+  val restore : t -> ?locale: string -> metadata -> metadata option Lwt.t
+  (** [restore t revision metadata] Return the metadata of the restored file.
+      A return value of [None] means that [metadata] is a folder, not a file.
+
+      The [metadata] contains the path and the rev of the file we want to
+      restore. A [metadata list] of the rev for a given filename can be
+      obtained from a call to {!revisions}.
+
       @param locale Specify language settings for user error messages
       and other language specific text. See
       {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox

--- a/tests/restore.ml
+++ b/tests/restore.ml
@@ -1,0 +1,20 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+(** Return the metadata of the first element of the metadata list returned
+    by revisions function on a given [filename]. *)
+
+let restore t fn =
+  D.revisions t fn >>= (function
+  | Some metadata_list -> D.restore t (List.hd metadata_list) >>= (function
+    | Some meta -> Lwt_io.printlf "%s" (Dropbox_j.string_of_metadata meta)
+    | None -> Lwt_io.printlf "%s is not a file" fn)
+  | None -> Lwt_io.printlf "No file %s" fn)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | _ -> Lwt_list.iter_p (restore t) args
+
+let () =
+  Common.run main

--- a/tests/revisions.ml
+++ b/tests/revisions.ml
@@ -1,0 +1,18 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+let revisions t fn =
+  D.revisions t fn >>= function
+  | Some metadata_list ->
+    let get_rev metadata = metadata.D.rev in
+    let revisions = String.concat ", rev: " (List.map get_rev metadata_list) in
+    Lwt_io.printlf "rev: %s" revisions
+  | None -> Lwt_io.printlf "No file %s" fn
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | _ -> Lwt_list.iter_p (revisions t) args
+
+let () =
+  Common.run main

--- a/tests/revisions.ml
+++ b/tests/revisions.ml
@@ -2,12 +2,12 @@ open Lwt
 module D = Dropbox_lwt_unix
 
 let revisions t fn =
-  D.revisions t fn >>= function
+  D.revisions t fn >>= (function
   | Some metadata_list ->
     let get_rev metadata = metadata.D.rev in
     let revisions = String.concat ", rev: " (List.map get_rev metadata_list) in
     Lwt_io.printlf "rev: %s" revisions
-  | None -> Lwt_io.printlf "No file %s" fn
+  | None -> Lwt_io.printlf "No file %s" fn)
 
 let main t args =
   match args with


### PR DESCRIPTION
To avoid the errors we get by implementing restore function basically and because revisions function return a metadata list, I decided to put metadata as a parameter. The rev field is always in metadata (exception for the the root/top-level path (not absolutely sure it's the only one)).

Revisions and restore functions cannot be used for folders (from what pattern matching for restore function).
