### PR TITLE
Implement shares and media functions

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -109,6 +109,22 @@ Executable "copy_ref"
   Install:      false
   CompiledObject: best
 
+Executable "shares"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       shares.ml
+  BuildDepends: dropbox.lwt
+  Install:      false
+  CompiledObject: best
+
+Executable "media"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       media.ml
+  BuildDepends: dropbox.lwt
+  Install:      false
+  CompiledObject: best
+
 
 Document API
   Title:           API reference for Dropbox

--- a/src/dropbox.atd
+++ b/src/dropbox.atd
@@ -78,3 +78,8 @@ type longpoll_delta = { changes: bool;
 
 type copy_ref = { copy_ref: string;
                   expires: date }
+
+type link = { url: string;
+              expires: date }
+
+type shared_link = json wrap <ocaml module="Dropbox_json.Link">

--- a/src/dropbox_json.ml
+++ b/src/dropbox_json.ml
@@ -90,3 +90,51 @@ module Video = struct
            | None -> l in
          `Assoc l
   end
+
+module Link = struct
+  type info = {url : string;
+               expires: Date.t;
+               visibility: string}
+
+  type t = [
+    | `None
+    | `Public of info
+    | `Team_only of info
+    | `Team_and_password of info
+    | `Shared_folder_only of info
+    | `Unknown of info
+    ]
+
+  let set_info url expires visibility = function
+    | ("url", `String d) -> url := d
+    | ("expires", `String d) -> expires := (Date.of_string d)
+    | ("visibility", `String d) -> visibility := d
+    | _ -> ()
+
+  let wrap : Yojson.Safe.json -> t = function
+    | `Assoc l ->
+       let url = ref "" in
+       let expires = ref (Date.of_string "") in
+       let visibility = ref "" in
+       List.iter (set_info url expires visibility) l;
+       let dict = { url = !url;
+                    expires = !expires;
+                    visibility = !visibility } in
+       (match !visibility with 
+       | "PUBLIC" -> `Public dict
+       | "TEAM_ONLY" -> `Team_only dict
+       | "TEAM_AND_PASSWORD" -> `Team_and_password dict
+       | "SHARED_FOLDER_ONLY" -> `Shared_folder_only dict
+       | _ -> `Unknown dict )
+    | _ -> `None
+
+  let unwrap : t -> Yojson.Safe.json = function
+    | `None -> `Null
+    | `Public info | `Team_only info | `Team_and_password info
+    | `Shared_folder_only info ->
+       let l = [("visibility", `String info.visibility)] in
+       let l = ("expires", `String(Date.to_string info.expires)) :: l in
+       let l = ("url", `String (info.url)) :: l in
+       `Assoc l
+    | `Unknown info -> `Null
+end

--- a/tests/media.ml
+++ b/tests/media.ml
@@ -1,0 +1,15 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+let media t fn =
+  D.media t fn >>= function
+  | Some media -> Lwt_io.printlf "%s" (Dropbox_j.string_of_link media)
+  | None -> Lwt_io.printlf "No file %s" fn
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | _ -> Lwt_list.iter_p (media t) args
+
+let () =
+  Common.run main

--- a/tests/shares.ml
+++ b/tests/shares.ml
@@ -1,0 +1,16 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+let shares t fn =
+  D.shares t fn >>= function
+  | Some shared_l -> Lwt_io.printlf "%s"
+                     (Dropbox_j.string_of_shared_link shared_l)
+  | None -> Lwt_io.printlf "No file %s" fn
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | _ -> Lwt_list.iter_p (shares t) args
+
+let () =
+  Common.run main


### PR DESCRIPTION
Not sure if this is how you wanted visibility field to be implemented.
I decided to set shared_link to `Unknown when the visibility string value is not the ones in the documentation and to make it`Null when unwrapping to avoid errors.
