### PR TITLE
Chunked upload and files_put functions

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -125,6 +125,30 @@ Executable "media"
   Install:      false
   CompiledObject: best
 
+Executable "stream_files_put"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       stream_files_put.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
+Executable "cohttp_body_files_put"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       cohttp_body_files_put.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
+Executable "chunked_upload"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       chunked_upload.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
 
 Document API
   Title:           API reference for Dropbox

--- a/src/dropbox.atd
+++ b/src/dropbox.atd
@@ -87,3 +87,7 @@ type visibility = json wrap <ocaml module="Dropbox_json.Visibility">
 type shared_link = { url: string;
                      expires: date;
                      visibility: visibility }
+
+type chunked_upload = { upload_id: string;
+                        offset: int;
+                        expires: date }

--- a/src/dropbox.ml
+++ b/src/dropbox.ml
@@ -226,6 +226,12 @@ module type S = sig
         expires: Date.t;
         visibility: visibility }
 
+  type chunked_upload
+    = Dropbox_t.chunked_upload
+    = { upload_id: string;
+        offset: int;
+        expires: Date.t }
+
   val get_file : t -> ?rev: string -> ?start: int -> ?len: int ->
                  string -> (metadata * string Lwt_stream.t) option Lwt.t
 
@@ -258,6 +264,22 @@ module type S = sig
                string -> shared_link option Lwt.t
 
   val media : t -> ?locale: string -> string -> link option Lwt.t
+
+  val stream_files_put : t -> ?locale: string -> ?overwrite: bool ->
+                         ?parent_rev: string -> ?autorename: bool -> string ->
+                         int -> string Lwt_stream.t -> metadata Lwt.t
+
+  val cohttp_body_files_put : t -> ?locale: string -> ?overwrite: bool ->
+                              ?parent_rev: string -> ?autorename: bool ->
+                              string -> int -> Cohttp_lwt_body.t ->
+                              metadata Lwt.t
+
+  val chunked_upload : t -> ?upload_id: string -> ?offset: int ->
+                       Cohttp_lwt_body.t -> chunked_upload Lwt.t
+
+  val commit_chunked_upload : t -> ?locale: string -> ?overwrite: bool ->
+                              ?parent_rev: string -> ?autorename: bool ->
+                              string -> string -> metadata Lwt.t
 
   module Fileops : sig
 
@@ -589,6 +611,62 @@ module Make(Client: Cohttp_lwt.Client) = struct
     let u = if locale <> "" then Uri.with_query u [("local",[locale])] else u in
     Client.post ~headers:(headers t) u
     >>= check_errors_404 media_of_response
+
+  let stream_files_put t ?(locale="") ?(overwrite=true) ?(parent_rev="")
+                       ?(autorename=true) fn len stream =
+    let headers = headers t in
+    (* let headers = Cohttp.Header.add (headers t)
+      "Content-Length" (string_of_int len) in *)
+    let u =
+      Uri.of_string("https://api-content.dropbox.com/1/files_put/auto/" ^ fn) in
+    let q = [("overwrite", [string_of_bool overwrite]);
+             ("autorename", [string_of_bool autorename])] in
+    let q = if locale <> "" then ("locale", [locale]) :: q else q in
+    let q = if parent_rev <> "" then ("parent_rev",[parent_rev]) :: q else q in
+    let u = Uri.with_query u q in
+    Client.put ~headers ~body:(Cohttp_lwt_body.of_stream stream) u
+    >>= check_errors >>= fun (_, body) -> Cohttp_lwt_body.to_string body
+    >>= fun body -> return(Json.metadata_of_string body)
+
+  let cohttp_body_files_put t ?(locale="") ?(overwrite=true) ?(parent_rev="")
+                            ?(autorename=true) fn len stream =
+    let headers = headers t in
+    (* let headers = Cohttp.Header.add (headers t)
+      "Content-Length" (string_of_int len) in *)
+    let u =
+      Uri.of_string("https://api-content.dropbox.com/1/files_put/auto/" ^ fn) in
+    let q = [("overwrite", [string_of_bool overwrite]);
+             ("autorename", [string_of_bool autorename])] in
+    let q = if locale <> "" then ("locale", [locale]) :: q else q in
+    let q = if parent_rev <> "" then ("parent_rev",[parent_rev]) :: q else q in
+    let u = Uri.with_query u q in
+    Client.put ~headers ~body:stream u
+    >>= check_errors >>= fun (_, body) -> Cohttp_lwt_body.to_string body
+    >>= fun body -> return(Json.metadata_of_string body)
+
+  let chunked_upload t ?(upload_id="") ?(offset=0) chunked_data =
+    let u = Uri.of_string("https://api-content.dropbox.com/1/chunked_upload") in
+    let q = if upload_id <> "" then [("upload_id",[upload_id])] else [] in
+    let q = if offset != 0 then ("offset",[string_of_int offset]) :: q else q in
+    let u = Uri.with_query u q in
+    Client.put ~body:chunked_data ~chunked:true ~headers:(headers t) u
+    >>= check_errors >>= fun (_, body) -> Cohttp_lwt_body.to_string body
+    >>= fun body -> return(Json.chunked_upload_of_string body)
+
+
+  let commit_chunked_upload t ?(locale="") ?(overwrite=true) ?(parent_rev="")
+                            ?(autorename=true) upload_id fn =
+    let u = Uri.of_string("https://api-content.dropbox.com/1\
+                           /commit_chunked_upload/auto/" ^ fn) in
+    let q = [("overwrite",[string_of_bool overwrite]);
+             ("autorename",[string_of_bool autorename]);
+             ("upload_id",[upload_id])] in
+    let q = if locale <> "" then ("locale", [locale]) :: q else q in
+    let q = if parent_rev <> "" then ("parent_rev",[parent_rev]) :: q else q in
+    let u = Uri.with_query u q in
+    Client.post ~headers:(headers t) u >>= check_errors
+    >>= fun (_, body) -> Cohttp_lwt_body.to_string body
+    >>= fun body -> return(Json.metadata_of_string body)
 
   module Fileops = struct
 

--- a/tests/chunked_upload.ml
+++ b/tests/chunked_upload.ml
@@ -1,0 +1,72 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+exception Wrong_offset of string
+
+let upload t fn =
+  (** We first open the file and get its size *)
+  Lwt_unix.(openfile fn [O_RDONLY] 0)
+  >>= fun fd -> Lwt_unix.stat fn >>= fun u ->
+  let size = u.Lwt_unix.st_size in
+  let lgth_buff = 4194304 in
+  (** If the size of the file is < 4Mo, we use cohttp_body_files_put
+      function. Otherwise chunked_upload function *)
+  if size < lgth_buff then
+    let buffer = Bytes.create size in
+    Lwt_unix.read fd buffer 0 size >>= fun _ ->
+    let stream = Cohttp_lwt_body.of_string (Bytes.to_string buffer) in
+    D.cohttp_body_files_put t fn size stream
+    >>= fun metadata -> Lwt_unix.close fd
+    >>= fun () -> Lwt_io.printlf "Send: %s\nMetadata:\n%s"
+                  fn (Dropbox_j.string_of_metadata metadata)
+  else (** The size is > 4Mo *)
+    let numb = size / lgth_buff in
+    let buffer = Bytes.create lgth_buff in
+
+    let rec send_chunks ?(upload_id="") ?(offset=0) lgth =
+      (** To see if the offset = the number of bytes actually read
+          by the function. If not, raise exception Wrong_offset *)
+      if offset = ((numb - lgth) * lgth_buff) then
+        (** Initializing with upload_id *)
+        if lgth = numb then
+          Lwt_unix.read fd buffer 0 lgth_buff >>= fun _ ->
+          let stream = Cohttp_lwt_body.of_string (Bytes.to_string buffer) in
+          D.chunked_upload t stream >>= fun chkd_upld ->
+          Lwt_io.printlf "Upload_id: %s" (chkd_upld.D.upload_id)
+          >>= fun () -> send_chunks ~upload_id:(chkd_upld.D.upload_id)
+                        ~offset:(chkd_upld.D.offset) (lgth-1)
+        (** The last time we enter in send_chunks *)
+        else if lgth = 0 then
+          Lwt_io.printlf "Offset: %i \nEnd of file" offset
+          >>= fun () -> Lwt_unix.read fd buffer 0 lgth_buff >>= fun size ->
+          let stream = Cohttp_lwt_body.of_string
+                       (Bytes.to_string (Bytes.sub buffer 0 size)) in
+          D.chunked_upload t ~upload_id ~offset stream
+          >>= fun _ -> return(upload_id)
+        else
+          Lwt_io.printlf "Offset: %i" offset
+          >>= fun () -> Lwt_unix.read fd buffer 0 lgth_buff >>= fun _ ->
+          let stream = Cohttp_lwt_body.of_string (Bytes.to_string buffer) in
+          D.chunked_upload t ~upload_id ~offset stream
+          >>= fun chkd_upld -> send_chunks ~upload_id
+                               ~offset:(chkd_upld.D.offset) (lgth-1)
+      else
+        let msg = "Last offset: " ^ (string_of_int offset) in
+        fail(Wrong_offset msg)
+    in
+
+    (** Finally, we finish the upload of the file by using
+        commit_chunked_upload *)
+    send_chunks numb >>= fun upload_id ->
+    D.commit_chunked_upload t upload_id fn
+    >>= fun metadata -> Lwt_unix.close fd
+    >>= fun () -> Lwt_io.printlf "Send: %s\nMetadata:\n%s"
+                  fn (Dropbox_j.string_of_metadata metadata)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file specified"
+  | _ -> Lwt_list.iter_p (upload t) args
+
+let () =
+  Common.run main

--- a/tests/cohttp_body_files_put.ml
+++ b/tests/cohttp_body_files_put.ml
@@ -1,0 +1,22 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+let upload t fn =
+  Lwt_unix.(openfile fn [O_RDONLY] 0)
+  >>= fun fd -> Lwt_unix.stat fn >>= fun u ->
+  let size = u.Lwt_unix.st_size in
+  let buffer = Bytes.create size in
+  Lwt_unix.read fd buffer 0 size >>= fun _ ->
+  let stream =Cohttp_lwt_body.of_string (Bytes.to_string buffer) in
+  D.cohttp_body_files_put t fn size stream
+  >>= fun m -> Lwt_unix.close fd
+  >>= fun () -> Lwt_io.printlf "Send: %s\nMetadata: %s\n"
+                fn (Dropbox_j.string_of_metadata m)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file specified"
+  | _ -> Lwt_list.iter_p (upload t) args
+
+let () =
+  Common.run main

--- a/tests/stream_files_put.ml
+++ b/tests/stream_files_put.ml
@@ -1,0 +1,26 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+let upload t fn =
+  Lwt_unix.(openfile fn [O_RDONLY] 0) >>= fun fd -> Lwt_unix.stat fn
+  >>= fun u -> return(u.Lwt_unix.st_size) >>= fun size ->
+  let read () =
+    let buffer = Bytes.create 1024 in
+    Lwt_unix.read fd buffer 0 1024 >>= fun len ->
+    match len with
+    | 1024 -> return(Some (Bytes.to_string buffer ))
+    | 0 -> return(None)
+    | a -> return(Some (Bytes.to_string (Bytes.sub buffer 0 a))) in
+  let stream =Lwt_stream.from read in
+  D.stream_files_put t fn size stream
+  >>= fun meta -> Lwt_unix.close fd
+  >>= fun () -> Lwt_io.printlf "Send: %s\nMetadata: \n%s"
+                fn (Dropbox_j.string_of_metadata meta)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file specified"
+  | _ -> Lwt_list.iter_p (upload t) args
+
+let () =
+  Common.run main


### PR DESCRIPTION
I made two files put functions : one using cohttp_body and the other using Lwt_stream.
These functions work well when Content-length is not provided.
I thought it wasn't necessary to make files put and commit_chunked_upload functions output optional.
