### PR TITLE
Fileops functions using a variant for fileops/copy

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -133,6 +133,46 @@ Executable "shared_folders"
   Install:      false
   CompiledObject: best
 
+Executable "copy_from_path"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       copy_from_path.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
+Executable "copy_from_ref"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       copy_from_ref.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
+Executable "delete"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       delete.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
+Executable "create_folder"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       create_folder.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
+Executable "move"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       move.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
 
 Document API
   Title:           API reference for Dropbox

--- a/src/dropbox.ml
+++ b/src/dropbox.ml
@@ -292,8 +292,21 @@ module type S = sig
                       -> t -> shared_folder list Lwt.t
 
   module Fileops : sig
+    type root_fileops = [ `Auto | `Dropbox | `Sandbox ]
 
+    type source = [ `From_path of string | `From_copy_ref of string ]
 
+    val copy : t -> ?locale: string -> ?root: root_fileops
+               -> source -> string -> metadata option Lwt.t
+
+    val create_folder : t -> ?locale: string -> ?root: root_fileops
+                        -> string -> metadata option Lwt.t
+
+    val delete : t -> ?locale: string -> ?root: root_fileops -> string ->
+                 metadata option Lwt.t
+
+    val move : t -> ?locale: string -> ?root: root_fileops -> string
+               -> string -> metadata option Lwt.t
   end
 end
 
@@ -639,7 +652,66 @@ module Make(Client: Cohttp_lwt.Client) = struct
     | _ -> return [Json.shared_folder_of_string body]
 
   module Fileops = struct
+    type root_fileops = [ `Auto | `Dropbox | `Sandbox ]
 
+    type source = [ `From_path of string | `From_copy_ref of string ]
 
+    let copy_uri =
+      Uri.of_string("https://api.dropbox.com/1/fileops/copy")
+
+    let copy t ?(locale="") ?(root=`Auto) source to_path =
+      let q = [("to_path",[to_path])] in
+      let q = if locale <> "" then ("locale",[locale]) :: q else q in
+      let q = match source with
+        | `From_path from_path -> ("from_path",[from_path]) :: q
+        | `From_copy_ref copy_ref -> ("from_copy_ref",[copy_ref]) :: q in
+      let q = match root with
+        | `Auto -> ("root",["auto"]) :: q
+        | `Dropbox -> ("root",["dropbox"]) :: q
+        | `Sandbox -> ("root",["sandbox"]) :: q in
+      let u = Uri.with_query copy_uri q in
+      Client.post ~headers:(headers t) u
+      >>= check_errors_404 metadata_of_response
+
+    let create_folder_uri =
+      Uri.of_string("https://api.dropbox.com/1/fileops/create_folder")
+
+    let create_folder t ?(locale="") ?(root=`Auto) path =
+      let q = [("path",[path])] in
+      let q = if locale <> "" then ("locale",[locale]) :: q else q in
+      let q = match root with
+        | `Auto -> ("root",["auto"]) :: q
+        | `Dropbox -> ("root",["dropbox"]) :: q
+        | `Sandbox -> ("root",["sandbox"]) :: q in
+      let u = Uri.with_query create_folder_uri q in
+      Client.post ~headers:(headers t) u
+      >>= check_errors_404 metadata_of_response
+
+    let delete_uri =
+      Uri.of_string("https://api.dropbox.com/1/fileops/delete")
+
+    let delete t ?(locale="") ?(root=`Auto) path =
+      let q = [("path",[path])] in
+      let q = if locale <> "" then ("locale",[locale]) :: q else q in
+      let q = match root with
+        | `Auto -> ("root",["auto"]) :: q
+        | `Dropbox -> ("root",["dropbox"]) :: q
+        | `Sandbox -> ("root",["sandbox"]) :: q in
+      let u = Uri.with_query delete_uri q in
+      Client.post ~headers:(headers t) u
+      >>= check_errors_404 metadata_of_response
+
+    let move_uri = Uri.of_string("https://api.dropbox.com/1/fileops/move")
+
+    let move t ?(locale="") ?(root=`Auto) from_path to_path =
+      let q = [("from_path",[from_path]);("to_path",[to_path])] in
+      let q = if locale <> "" then ("locale",[locale]) :: q else q in
+      let q = match root with
+        | `Auto -> ("root",["auto"]) :: q
+        | `Dropbox -> ("root",["dropbox"]) :: q
+        | `Sandbox -> ("root",["sandbox"]) :: q in
+      let u = Uri.with_query move_uri q in
+      Client.post ~headers:(headers t) u
+      >>= check_errors_404 metadata_of_response
   end
 end

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -699,8 +699,105 @@ module type S = sig
       list of members and a list of groups for the shared folder. *)
 
   module Fileops : sig
+    type root_fileops = [ `Auto | `Dropbox | `Sandbox ]
 
+    type source = [ `From_path of string | `From_copy_ref of string ]
+    (** A polymorphic variant used in the function {! copy} with two values :
 
+        - `From_path : Specifies the file or folder to be copied from
+                       relative to root.
+
+        - `From_copy_ref : Specifies a [copy_ref] generated from a previous
+                           {!copy_ref} call. *)
+
+    val copy : t -> ?locale: string -> ?root: root_fileops
+               -> source -> string -> metadata option Lwt.t
+  (** [copy t source to_path] Return the metadata for the copy of
+      the file or folder.
+
+      @param to_path Specifies the destination path, including the new name
+      for the file or folder, relative to root.
+
+      @param root The root relative to which [from_path] and [to_path] are
+      specified. Valid values are `Auto (default), `Sandbox, and `Dropbox.
+
+      @param locale Specify language settings for user error messages
+      and other language specific text.  See
+      {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox
+      documentation} for more information about supported locales.
+
+      Possible errors:
+      Invalid_oauth An invalid copy operation was attempted (e.g. there is
+      already a file at the given destination, or trying to copy a shared
+      folder).
+
+      Not_acceptable Too many files would be involved in the operation for
+      it to complete successfully. The limit is currently 10,000 files and
+      folders. *)
+
+    val create_folder : t -> ?locale: string -> ?root: root_fileops
+                        -> string -> metadata option Lwt.t
+  (** [create_folder path root] return the metadata for the new folder.
+
+      @param root The root relative to which path is specified. Valid values
+      are `Auto (default), `Sandbox, and `Dropbox.
+
+      @param path The path to the new folder to create relative to root.
+
+      @param locale Specify language settings for user error messages
+      and other language specific text.  See
+      {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox
+      documentation} for more information about supported locales.
+
+      Possible error:
+      Invalid_oauth There is already a folder at the given destination. *)
+
+    val delete : t -> ?locale: string -> ?root: root_fileops -> string ->
+                 metadata option Lwt.t
+  (** [delete path root] Return the metadata for the deleted file or folder.
+
+      @param root The root relative to which path is specified. Valid values
+      are `Auto (default), `Sandbox, and `Dropbox.
+
+      @param path The path to the file or folder to be deleted.
+
+      @param locale Specify language settings for user error messages
+      and other language specific text.  See
+      {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox
+      documentation} for more information about supported locales.
+
+      Possible errors:
+      Not_acceptable Too many files would be involved in the operation for
+      it to complete successfully. The limit is currently 10,000 files and
+      folders. *)
+
+    val move : t -> ?locale: string -> ?root: root_fileops -> string
+               -> string -> metadata option Lwt.t
+  (** [move from_path to_path root] Return the metadata for the moved file or
+      folder.
+
+      @param root The root relative to which from_path and to_path are
+      specified. Valid values are `Auto (default), `Sandbox, and `Dropbox.
+
+      @param from_path Specifies the file or folder to be moved from relative
+      to root.
+
+      @param to_path Specifies the destination path, including the new name
+      for the file or folder, relative to root.
+
+      @param locale Specify language settings for user error messages
+      and other language specific text.  See
+      {{:https://www.dropbox.com/developers/core/docs#param.locale}Dropbox
+      documentation} for more information about supported locales.
+
+      Possible errors:
+      Invalid_oauth An invalid move operation was attempted (e.g. there
+      is already a file at the given destination, or moving a shared folder
+      into a shared folder).
+
+      Not_acceptable Too many files would be involved in the operation for
+      it to complete successfully. The limit is currently 10,000 files and
+      folders.*)
   end
 end
 

--- a/tests/copy_from_path.ml
+++ b/tests/copy_from_path.ml
@@ -1,0 +1,17 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+(** We assume there is only two entries in command line and that Sys.argv.(0)
+    is the from_path, Sys.argv.(1) is the to_path *)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | [from_path; to_path] -> D.Fileops.copy t (`From_path from_path) to_path
+      >>= (function
+      | Some m -> Lwt_io.printlf "%s" (Dropbox_j.string_of_metadata m)
+      | None -> Lwt_io.printlf "No such from_path as %s" from_path)
+  | _ -> Lwt_io.printf "%s [from_path] [to_path]\n" Sys.argv.(0)
+
+let () =
+  Common.run main

--- a/tests/copy_from_ref.ml
+++ b/tests/copy_from_ref.ml
@@ -1,0 +1,17 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+(** We assume there is only two entries in command line and that Sys.argv.(0)
+    is the from_copy_ref, Sys.argv.(1) is the to_path *)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | [copy_ref; to_path] -> D.Fileops.copy t (`From_copy_ref copy_ref) to_path
+      >>= (function
+      | Some m -> Lwt_io.printlf "%s" (Dropbox_j.string_of_metadata m)
+      | None -> Lwt_io.printlf "No such from_path as %s" copy_ref)
+  | _ -> Lwt_io.printf "%s [from_copy_ref] [to_path]\n" Sys.argv.(0)
+
+let () =
+  Common.run main

--- a/tests/create_folder.ml
+++ b/tests/create_folder.ml
@@ -1,0 +1,23 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+(** We assume there is only two entries in command line and that Sys.argv.(0)
+    is the path of the folder and Sys.argv.(1) is the root *)
+
+let string_to_root a = match a with
+  | "auto" -> `Auto
+  | "dropbox" -> `Dropbox
+  | "sandbox" -> `Sandbox
+  | _ -> invalid_arg "root must be auto, dropbox or sandbox"
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | [path; root] -> D.Fileops.create_folder t ~root:(string_to_root root) path
+      >>= (function
+      | Some m -> Lwt_io.printlf "%s" (Dropbox_j.string_of_metadata m)
+      | None -> Lwt_io.printlf  "Should not happen")
+  | _ -> Lwt_io.printf "%s [path] <root>\n" Sys.argv.(0)
+
+let () =
+  Common.run main

--- a/tests/delete.ml
+++ b/tests/delete.ml
@@ -1,0 +1,23 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+(** We assume there is only two entries in command line and that Sys.argv.(0)
+    is the path and Sys.argv.(1) the root *)
+
+let string_to_root a = match a with
+  | "auto" -> `Auto
+  | "dropbox" -> `Dropbox
+  | "sandbox" -> `Sandbox
+  | _ -> invalid_arg "root must be auto, dropbox or sandbox"
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | [path; root] -> D.Fileops.delete t ~root:(string_to_root root) path
+      >>= (function
+      | Some m -> Lwt_io.printlf "%s" (Dropbox_j.string_of_metadata m)
+      | None -> Lwt_io.printlf "No file %s" path)
+  | _ -> Lwt_io.printf "%s [path] <root>\n" Sys.argv.(0)
+
+let () =
+  Common.run main

--- a/tests/move.ml
+++ b/tests/move.ml
@@ -1,0 +1,17 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+(** We assume there is only two entries in command line and that Sys.argv.(0)
+    is from_path, Sys.argv.(1) is to_path.*)
+
+let main t args =
+  match args with
+  | [] -> Lwt_io.printlf "No file or folder specified"
+  | [from_path; to_path] -> D.Fileops.move t from_path to_path
+      >>= (function
+      | Some m -> Lwt_io.printlf "%s" (Dropbox_j.string_of_metadata m)
+      | None -> Lwt_io.printlf "No file %s" from_path)
+  | _ -> Lwt_io.printf "%s [from_path] [to_path]" Sys.argv.(0)
+
+let () =
+  Common.run main


### PR DESCRIPTION
For copy function: in order to avoid errors when putting from_path and from_copy_ref at the same time, I made a type called source consisting of [ `From_path of string |`From_copy_ref of string ]
which replace from_path and from_copy_ref as a parameter.
I also made two test functions for fileops/copy to test it when using a copy_ref or a path.
