### PR TITLE
Implement a function creating n files on a designed folder

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -213,6 +213,14 @@ Executable "move"
   Install:      false
   CompiledObject: best
 
+Executable "test"
+  Build$:       flag(tests)
+  Path:         tests
+  MainIs:       test.ml
+  BuildDepends: dropbox.lwt, unix
+  Install:      false
+  CompiledObject: best
+
 
 Document API
   Title:           API reference for Dropbox

--- a/src/dropbox.mli
+++ b/src/dropbox.mli
@@ -21,7 +21,7 @@ type error =
   (** Your app is making too many requests and is being rate limited.
       [Too_many_requests] can trigger on a per-app or per-user
       basis. *)
-  | Try_later of int option * error_description
+  | Try_later of float option * error_description
   (** [Try_later(sec, e)] If [sec = Some s], this means your app is
       being rate limited and you must retry after [s] seconds.
       Otherwise, this indicates a transient server error, and your app

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -1,0 +1,34 @@
+open Lwt
+module D = Dropbox_lwt_unix
+
+(** The function create an folder called "test-ocaml-dropbox"
+    and create [n] different files within it.
+    To delete the folder, just use the function {!delete} with
+    "test-ocaml-dropbox" as argument. **)
+
+let create_list length =
+  let rec incr l acc =
+    if l < 0 then acc
+    else incr (l-1) ((string_of_int l)::acc) in
+  incr length []
+
+let create_files t length=
+  D.create_folder t "test-ocaml-dropbox"
+  >>= function
+  | `Invalid s -> Lwt_io.printlf "Invalid: %s" s
+  | `Some m -> Lwt_io.printlf "%s" (Dropbox_j.string_of_metadata m)
+  >>= fun () ->
+  let put_files path =
+    D.files_put t ("test-ocaml-dropbox/" ^ path ^ ".txt") (`String path)
+    >>= fun m -> Lwt_io.printlf "%s" (m.D.path)
+  in
+  Lwt_list.iter_p put_files (create_list length)
+  >>= fun () -> Lwt_io.printlf "Wrote %i files in test-ocaml-dropbox/" length
+
+let main t args =
+  match args with
+  | [length] -> create_files t (int_of_string length)
+  | _ -> Lwt_io.printlf "%s <number of files to be created>\n" Sys.argv.(0)
+
+let () =
+  Common.run main


### PR DESCRIPTION
Not intended to be merged directly.

I tried to implement a function who creates n different files. When trying to do this with Lwt_stream.iter_p , I get an error 503 (referring to the API : "If the response includes the Retry-After header, this means your OAuth 1.0 app is being rate limited.").

Assuming that we are using OAuth 2.0, I should get an error 429 ("Your app is making too many requests and is being rate limited. 429s can trigger on a per-app or per-user basis.") and not 503. I don't know how to overcome this problem.

By the way, it works fine when the threads are serialised.
